### PR TITLE
Include dependency on OpenBLAS using OpenMP explcitly

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 mpi:
-  - openmpi
   - mpich
+  - openmpi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "spla" %}
 {% set version = "1.6.1" %}
 
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set mpi = mpi or "openmpi" %}
 {% set mpi_prefix = "mpi_" + mpi %}
@@ -37,10 +37,14 @@ outputs:
         - pkg-config
       host:
         - {{ mpi }}
+        - _openmp_mutex
         - libcblas
+        - "openblas >=0.3.30 *openmp_*"
       run:
         - {{ mpi }}
+        - _openmp_mutex
         - libcblas
+        - "openblas >=0.3.30 *openmp_*"
     test:
       commands:
         - test -f "${PREFIX}/lib/libspla${SHLIB_EXT}"
@@ -50,8 +54,6 @@ outputs:
     script: build-spla.sh
     build:
       string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
-      run_exports:
-        - {{ pin_subpackage("spla-static", max_pin="x.x") }}
     requirements:
       build:
         - {{ compiler("c") }}
@@ -64,10 +66,14 @@ outputs:
         - pkg-config
       host:
         - {{ mpi }}
+        - _openmp_mutex
         - libcblas
+        - "openblas >=0.3.30 *openmp_*"
       run:
         - {{ mpi }}
+        - _openmp_mutex
         - libcblas
+        - "openblas >=0.3.30 *openmp_*"
     test:
       commands:
         - test -f "${PREFIX}/lib/libspla.a"


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
- Ensure availability of OpenBLAS using OpenMP instead of relying on the default `libcblas` using pthreads
- Remove run_exports section for static variant